### PR TITLE
feat(docs): enforce test-runner agent for all test execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # CLAUDE.md
 
 ## Identity & Communication Style
+
 - Be direct and concise - max 4 lines unless detail requested
 - Skip preambles like "I'll help you..." or "Let me..."
 - Action over explanation - do first, explain only if asked
@@ -9,33 +10,38 @@
 ## Coding Standards
 
 ### General Principles
+
 - Prefer editing existing files over creating new ones
 - Never create documentation unless explicitly requested
 - Follow existing code patterns and conventions in each project
 - Always check for existing dependencies before suggesting new ones
 
 ### Code Style
+
 - Use 2 spaces for indentation (except Python: 4 spaces)
 - Keep functions under 30 lines when possible
 - Descriptive variable names over comments
 - Early returns over nested conditionals
 
 ### Git Workflow
+
 - Branch naming: `feat/`, `fix/`, `chore/`, `docs/` prefixes
 - Commit format: `type(scope): description` (conventional commits)
 - Never commit directly to main/master
-- Always run tests before suggesting commits
+- Always run tests before suggesting commits (via test-runner agent ONLY)
 
 ## Common Commands & Aliases
 
 ### Frequently Used Commands
-- Generic quality control check: `bun run ci` in the root of the project
-    - Build: `bun run build`
-    - Test: `bun run test`
-    - Lint: `bun run lint`
-    - Type check: `bun run typecheck`
+
+- Generic quality control check: Use test-runner agent via Task tool (NOT direct commands)
+  - Build: `bun run build` (can be run directly for build-only tasks)
+  - Test: MUST use test-runner agent - NEVER run `bun run test` directly
+  - Lint: MUST use test-runner agent - NEVER run `bun run lint` directly
+  - Type check: `bun run typecheck` (can be run directly for type-checking only)
 
 ### System Information
+
 - Default shell: zsh
 - Package manager preference: bun > pnpm > npm > yarn
 - Editor: Cursor
@@ -43,33 +49,42 @@
 ## Tool Preferences
 
 ### Language-Specific
+
 - JavaScript/TypeScript: Prefer modern ES6+ syntax, async/await over promises
 - Python: Type hints for functions, use pathlib over os.path
 - Shell: Prefer bash over sh, use shellcheck conventions
 
 ### Testing
-- Run tests after implementing features
+
+- CRITICAL: ALWAYS use the test-runner agent for ALL test execution - NO EXCEPTIONS
+- The test-runner agent MUST be invoked using Task tool after ANY code changes
+- NEVER run `bun run test`, `npm test`, or any test commands directly via Bash
+- Run tests after implementing features (via test-runner agent)
 - Prefer unit tests with clear test names
 - Mock external dependencies
 
 ## Security & Best Practices
+
 - Never log or commit sensitive information
 - Always validate user input
 - Prefer environment variables for configuration
 - Check dependencies for known vulnerabilities
 
 ## Personal Workflow Preferences
+
 - Show me git diff before committing
 - Run linting/formatting before showing final code
 - When debugging, check logs first, then add targeted logging
 - For performance issues, measure first, optimize second
 
 ## Multi-Model Collaboration Preferences
+
 - Use Gemini for validation: `mcp__gemini_cli__ask_gemini --changeMode`
 - Consult GPT-5 via codex for complex debugging
 - You (Claude) handle all implementation
 
 ## Quick Reference Reminders
+
 - Working on Mac/Linux/WSL environments primarily
 - Prefer CLI tools over GUI applications
 - Focus on automation and reproducibility


### PR DESCRIPTION
## What does this PR do?
Enforces the use of the test-runner agent for all test execution by updating CLAUDE.md with critical rules that mandate using the test-runner agent via the Task tool instead of running test commands directly through Bash.

## Why are we making this change?
To ensure consistent test execution patterns and prevent direct test command execution via Bash, which can lead to inconsistent behavior and missed test failures.

## How does it work?
- Updates CLAUDE.md with explicit rules prohibiting direct test command execution
- Mandates the use of test-runner agent via Task tool for all test operations
- Maintains flexibility for build and typecheck commands when used for non-testing purposes
- Provides clear guidance on when and how to use the test-runner agent

## Changes included
```
e0b28bd feat(docs): enforce test-runner agent for all test execution
```

## Testing
- [x] Documentation changes reviewed
- [x] Rules clearly defined and enforceable
- [x] No breaking changes to existing workflow

## Review checklist
- [x] Code follows project conventions
- [x] No unrelated changes included
- [x] Documentation updated appropriately
- [x] Breaking changes documented (N/A)

## Additional context
This change establishes a critical workflow rule to ensure all test execution goes through the dedicated test-runner agent, improving consistency and reliability of the testing process.