### PR TITLE
feat(install): add support for Claude output-styles configuration

### DIFF
--- a/.claude/output-styles/hyper-consise.md
+++ b/.claude/output-styles/hyper-consise.md
@@ -1,0 +1,48 @@
+---
+name: Hyper Concise
+description: Ultra-concise responses with diff-only code presentation and smart educational detection
+---
+
+## Communication Style
+
+- Maximum 2 lines per response unless user explicitly requests details
+- Zero preambles, pleasantries, or confirmations
+- Action-first: execute immediately, explain only if asked
+- Never use emojis or formatting unless requested
+
+## Code Presentation Rules
+
+- ALWAYS show diffs only, never full files
+- Use standard diff format: `- removed` `+ added` with context lines
+- Show minimal context (3 lines max before/after changes)
+- Multiple file changes: separate diffs with `--- filename ---`
+- Never show unchanged code sections
+
+## Smart Educational Detection
+
+- Detect "new things": first-time library usage, unfamiliar patterns, or novel concepts in codebase
+- For new things: add ONE concise explanatory line after the diff
+- For familiar patterns: zero explanation
+- Use context from existing codebase patterns to determine familiarity
+
+## Automation Rules
+
+- Fully automate all possible actions without asking permission
+- Run quality checks automatically after code changes
+- Follow user instructions precisely with zero deviation or interpretation
+- Never suggest alternatives unless current approach fails
+
+## Response Structure
+
+```
+[Action taken in 1-2 words]
+[Diff only]
+[Educational line if new concept detected]
+```
+
+## Quality Control
+
+- Auto-run test-runner agent after any code changes
+- Auto-run build/lint only when explicitly required
+- Never ask before running standard checks
+- Report only failures, never successes

--- a/install.sh
+++ b/install.sh
@@ -684,6 +684,14 @@ USAGE
       log_success "Installed CLAUDE.md to ~/.claude/"
     fi
     
+    # Install output-styles
+    if [ -d "$src_base/output-styles" ]; then
+      printf "\n"
+      print_color "$BOLD" "Installing Output Styles..."
+      cp -r "$src_base/output-styles" "$claude_code_dir/"
+      log_success "Installed output-styles to ~/.claude/"
+    fi
+    
     # Create manifest for uninstall
     local manifest="$claude_code_dir/.ai-rules-manifest.json"
     cat > "$manifest" <<EOF
@@ -695,6 +703,7 @@ USAGE
     "settings.json",
     "agents/",
     "commands/",
+    "output-styles/",
     "CLAUDE.md"
   ]
 }

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -374,6 +374,13 @@ USAGE
       print_color "$RED" "  - CLAUDE.md"
     fi
     
+    # Show output-styles that would be removed
+    if [ -d "$claude_code_dir/output-styles" ]; then
+      printf "\n"
+      print_color "$BOLD" "🎨 Output styles that would be removed:"
+      print_color "$RED" "  - output-styles/"
+    fi
+    
     if [ -f "$claude_code_dir/.ai-rules-manifest.json" ]; then
       print_color "$RED" "\n  • AI Rules manifest file would be removed"
     fi
@@ -411,6 +418,12 @@ USAGE
     if [ -f "$claude_code_dir/CLAUDE.md" ]; then
       rm "$claude_code_dir/CLAUDE.md"
       log_success "Removed CLAUDE.md"
+    fi
+    
+    # Remove output-styles installed by AI Rules
+    if [ -d "$claude_code_dir/output-styles" ]; then
+      rm -rf "$claude_code_dir/output-styles"
+      log_success "Removed output-styles directory"
     fi
     
     # Remove manifest


### PR DESCRIPTION
## What does this PR do?
Adds support for Claude output-styles configuration to the ai-rules installation system.

## Why are we making this change?
Claude Code now supports output-styles configuration files that customize response formatting and behavior. This enhancement allows ai-rules to manage these configurations as part of the standard installation/uninstallation process.

## How does it work?
- Adds a hyper-concise output style configuration that provides ultra-concise responses with diff-only code presentation
- Updates install.sh to detect and copy the output-styles directory to ~/.claude/
- Updates uninstall.sh to properly remove output-styles during cleanup
- Includes output-styles in the manifest for proper tracking

## Changes included
```
90a13da feat(install): add support for Claude output-styles configuration
```

## Testing
- [ ] Installation copies output-styles correctly
- [ ] Uninstallation removes output-styles properly
- [ ] Manifest tracking works as expected
- [ ] Output style configuration is valid

## Review checklist
- [ ] Code follows project conventions
- [ ] No unrelated changes included
- [ ] Installation/uninstallation logic is robust
- [ ] Configuration files are properly formatted

## Additional context
This change extends the ai-rules system to manage Claude's new output-styles feature, ensuring users get a complete configuration setup when installing ai-rules.